### PR TITLE
Add amp_template as property

### DIFF
--- a/coupled_cluster/tdcc.py
+++ b/coupled_cluster/tdcc.py
@@ -56,6 +56,11 @@ class TimeDependentCoupledCluster(metaclass=abc.ABCMeta):
     def amplitudes_from_array(self, y):
         """Construct AmplitudeContainer from numpy array."""
         return self._amp_template.from_array(y)
+   
+    @property
+    def amp_template(self):
+        """Returns static _amp_template, for setting initial conditions etc"""
+        return self._amp_template
 
     @abc.abstractmethod
     def rhs_t_0_amplitude(self, *args, **kwargs):


### PR DESCRIPTION
Useful to get the correct shape of the AmplitudeContainer (or OACCVector) for initial guesses.