### PR TITLE
Restrict the number of updates of the Hamiltonian

### DIFF
--- a/coupled_cluster/oatdcc.py
+++ b/coupled_cluster/oatdcc.py
@@ -46,7 +46,8 @@ class OATDCC(TimeDependentCoupledCluster, metaclass=abc.ABCMeta):
             self.truncation, n_prime, m_prime, np=self.np
         )
         self._amp_template = OACCVector(*_amp, C, C_tilde, np=self.np)
-        self.update_hamiltonian(current_time=0, C=C, C_tilde=C_tilde)
+
+        self.last_timestep = None
 
     @abc.abstractmethod
     def one_body_density_matrix(self, t, l):
@@ -84,6 +85,11 @@ class OATDCC(TimeDependentCoupledCluster, metaclass=abc.ABCMeta):
         pass
 
     def update_hamiltonian(self, current_time, y=None, C=None, C_tilde=None):
+        if self.last_timestep == current_time:
+            return
+
+        self.last_timestep = current_time
+
         if y is not None:
             _, _, C, C_tilde = self._amp_template.from_array(y)
         elif C is not None and C_tilde is not None:

--- a/coupled_cluster/tdcc.py
+++ b/coupled_cluster/tdcc.py
@@ -31,6 +31,8 @@ class TimeDependentCoupledCluster(metaclass=abc.ABCMeta):
             self.truncation, self.system.n, self.system.m, np=self.np
         )
 
+        self.last_timestep = None
+
     @property
     @abc.abstractmethod
     def truncation(self):
@@ -194,6 +196,10 @@ class TimeDependentCoupledCluster(metaclass=abc.ABCMeta):
         return self.system.compute_particle_density(rho_qp)
 
     def update_hamiltonian(self, current_time, y):
+        if self.last_timestep == current_time:
+            return
+
+        self.last_timestep = current_time
 
         if self.system.has_one_body_time_evolution_operator:
             self.h = self.system.h_t(current_time)


### PR DESCRIPTION
This optimization reduces the number of times the Hamiltonian needs to be updated. Originally the test 
`test_time_dependent_observables` in `tests/test_tdccd.py` updated the Hamiltonian `8074` times, whereas now this has been reduced to `5062` times. For `test_oatdccd_helium` in `tests/test_oatdccd.py` the situation moves from `8013` times to `5017` times when using the `dopri5` integrator. As the gauss-integrator does not evaluate the right-hand side in the last time step this optimization makes little difference.