### PR TITLE
Fix the time-dependent tests

### DIFF
--- a/tests/test_oatdccd.py
+++ b/tests/test_oatdccd.py
@@ -73,7 +73,7 @@ def test_oatdccd_helium():
 
         td_energies[i] = oatdccd.compute_energy(r.t, r.y)
         dip_z[i] = oatdccd.compute_one_body_expectation_value(
-            r.t, r.y, system.dipole_moment[2]
+            r.t, r.y, system.position[2]
         )
 
         i += 1
@@ -81,7 +81,7 @@ def test_oatdccd_helium():
 
     td_energies[i] = oatdccd.compute_energy(r.t, r.y)
     dip_z[i] = oatdccd.compute_one_body_expectation_value(
-        r.t, r.y, system.dipole_moment[2]
+        r.t, r.y, system.position[2]
     )
 
     np.testing.assert_allclose(

--- a/tests/test_tdccsd.py
+++ b/tests/test_tdccsd.py
@@ -262,7 +262,7 @@ def test_tdccsd():
 
         td_energies[i] = tdccsd.compute_energy(r.t, r.y)
         dip_z[i] = tdccsd.compute_one_body_expectation_value(
-            r.t, r.y, system.dipole_moment[2]
+            r.t, r.y, system.position[2]
         ).real
         td_overlap[i] = tdccsd.compute_overlap(r.t, y0, r.y)
 
@@ -271,7 +271,7 @@ def test_tdccsd():
 
     td_energies[i] = tdccsd.compute_energy(r.t, r.y)
     dip_z[i] = tdccsd.compute_one_body_expectation_value(
-        r.t, r.y, system.dipole_moment[2]
+        r.t, r.y, system.position[2]
     ).real
     td_overlap[i] = tdccsd.compute_overlap(r.t, y0, r.y)
 

--- a/tests/test_tdrccsd.py
+++ b/tests/test_tdrccsd.py
@@ -102,7 +102,7 @@ def test_tdrccsd_vs_tdccsd():
     dip_z[0] = tdrccsd.compute_one_body_expectation_value(
         r.t,
         r.y,
-        system.dipole_moment[polarization_direction],
+        system.position[polarization_direction],
         make_hermitian=False,
     )
     tau0[0] = t[0][0]
@@ -129,7 +129,7 @@ def test_tdrccsd_vs_tdccsd():
         dip_z[i + 1] = tdrccsd.compute_one_body_expectation_value(
             r.t,
             r.y,
-            system.dipole_moment[polarization_direction],
+            system.position[polarization_direction],
             make_hermitian=False,
         )
         tau0[i + 1] = t[0][0]


### PR DESCRIPTION
Using `system.position` instead of `system.dipole_moment` in the calculation of the expectation value of the dipole moment in the time-dependent tests gives the same results as before the new definition of the dipole moment in quantum-systems. Alternatively the charge could have been set to `1`.