### PR TITLE
Same sign convention in orbital rotations as in OACC

### DIFF
--- a/coupled_cluster/omp2/omp2.py
+++ b/coupled_cluster/omp2/omp2.py
@@ -191,7 +191,7 @@ class OMP2(CCD):
             )
             residual_w_ai = np.linalg.norm(w_ai)
 
-            self.kappa[self.v, self.o] += w_ai / self.d_t_1
+            self.kappa[self.v, self.o] -= w_ai / self.d_t_1
 
             C = expm(self.kappa - self.kappa.T)
             Ctilde = C.T

--- a/coupled_cluster/omp2/p_space_equations.py
+++ b/coupled_cluster/omp2/p_space_equations.py
@@ -1,34 +1,68 @@
 def compute_eta(h, u, rho_qp, rho_qspr, o, v, np):
+    eta = np.zeros(h.shape, dtype=np.complex128)
+    A_ibaj = compute_A_ibaj(rho_qp, o, v, np=np)
+    R_ia = compute_R_ia(h, u, rho_qp, rho_qspr, o, v, np=np)
 
-    # Eq. (23) in: https://aip.scitation.org/doi/10.1063/1.5020633
-    R_ai = compute_R_tilde_ai(h, u, rho_qp, rho_qspr, o, v, np)
+    A_iajb = A_ibaj.transpose(0, 2, 3, 1)
+    eta_jb = -1j * np.linalg.tensorsolve(A_iajb, R_ia)
 
-    # Solve P-space equations for X^b_j
+    eta[o, v] += eta_jb
+    eta[v, o] -= eta_jb.conj().T
+
+    return eta
+
+
+def compute_A_ibaj(rho_qp, o, v, np):
     delta_ij = np.eye(o.stop)
     delta_ba = np.eye(v.stop - o.stop)
 
-    A_aibj = np.einsum("ab, ji -> aibj", delta_ba, rho_qp[o, o])
-    A_aibj -= np.einsum("ji, ab -> aibj", delta_ij, rho_qp[v, v])
+    A_ibaj = np.einsum("ba, ij -> ibaj", delta_ba, rho_qp[o, o])
+    A_ibaj -= np.einsum("ij, ba -> ibaj", delta_ij, rho_qp[v, v])
 
-    X_bj = -1j * np.linalg.tensorsolve(A_aibj, R_ai)
-    X = np.zeros(h.shape, dtype=np.complex128)
+    return A_ibaj
 
-    X[v, o] = X_bj
-    X[o, v] = -X_bj.T.conj()
 
-    return X
+def compute_R_ia(h, u, rho_qp, rho_qspr, o, v, np):
+    R_ia = np.dot(rho_qp[o, o], h[o, v])
+    R_ia -= np.dot(h[o, v], rho_qp[v, v])
+    R_ia += 0.5 * np.tensordot(
+        # rho^{is}_{pr}
+        rho_qspr[o, :, :, :],
+        # u^{pr}_{as}
+        u[:, :, v, :],
+        # axes=((s, p, r), (s, p, r))
+        axes=((1, 2, 3), (3, 0, 1)),
+    )
+    R_ia -= 0.5 * np.tensordot(
+        # u^{ir}_{qs}
+        u[o, :, :, :],
+        # rho^{qs}_{ar}
+        rho_qspr[:, :, v, :],
+        # axes=((r, q, s), (r, q, s))
+        axes=((1, 2, 3), (3, 0, 1)),
+    )
+
+    return R_ia
 
 
 def compute_R_tilde_ai(h, u, rho_qp, rho_qspr, o, v, np):
-
-    R_ai = np.einsum("aj,ji->ai", h[v, o], rho_qp[o, o])
-    R_ai += 0.5 * np.einsum(
-        "arqs,qsir->ai", u[v, :, :, :], rho_qspr[:, :, o, :], optimize=True
+    R_tilde_ai = np.dot(rho_qp[v, v], h[v, o])
+    R_tilde_ai -= np.dot(h[v, o], rho_qp[o, o])
+    R_tilde_ai += 0.5 * np.tensordot(
+        # rho^{as}_{pr}
+        rho_qspr[v, :, :, :],
+        # u^{pr}_{is}
+        u[:, :, o, :],
+        # axes=((s, p, r), (s, p, r))
+        axes=((1, 2, 3), (3, 0, 1)),
+    )
+    R_tilde_ai -= 0.5 * np.tensordot(
+        # u^{ar}_{qs}
+        u[v, :, :, :],
+        # rho^{qs}_{ir}
+        rho_qspr[:, :, o, :],
+        # axes=((r, q, s), (r, q, s))
+        axes=((1, 2, 3), (3, 0, 1)),
     )
 
-    R_ai -= np.einsum("ab, bi->ai", rho_qp[v, v], h[v, o])
-    R_ai -= 0.5 * np.einsum(
-        "qsir,arqs->ai", u[:, :, o, :], rho_qspr[v, :, :, :], optimize=True
-    )
-
-    return R_ai
+    return R_tilde_ai


### PR DESCRIPTION
This pull request use the same sign convention in the orbital rotations in OMP2 as in OACC. 