### PR TITLE
Do not use self.contract

### DIFF
--- a/coupled_cluster/romp2/tdromp2.py
+++ b/coupled_cluster/romp2/tdromp2.py
@@ -62,11 +62,9 @@ class TDROMP2(OATDCC):
         rho_qspr = self.compute_two_body_density_matrix(current_time, y)
 
         return (
-            self.contract("pq,qp->", self.h_prime, rho_qp, optimize=True)
+            contract("pq,qp->", self.h_prime, rho_qp, optimize=True)
             + 0.5
-            * self.contract(
-                "pqrs,rspq->", self.u_prime, rho_qspr, optimize=True
-            )
+            * contract("pqrs,rspq->", self.u_prime, rho_qspr, optimize=True)
             + self.system.nuclear_repulsion_energy
         )
 


### PR DESCRIPTION
The contract function is imported from opt_einsum and is not a property of TDROMP2. This is just a typo that leads to an AttributeError when calling compute_energy in TDROMP2.