### PR TITLE
Compute reference energy in RCCSD

### DIFF
--- a/coupled_cluster/rccsd/rccsd.py
+++ b/coupled_cluster/rccsd/rccsd.py
@@ -185,7 +185,7 @@ class RCCSD(CoupledCluster):
             optimize=True,
         )
 
-        e_ref = 0
+        e_ref = self.system.compute_reference_energy()
 
         return e_corr + e_ref
 

--- a/tests/test_rccsd_ground_state_properties.py
+++ b/tests/test_rccsd_ground_state_properties.py
@@ -24,7 +24,7 @@ def compute_ground_state_properties(molecule, basis):
     l_kwargs = dict(tol=conv_tol)
 
     rccsd.compute_ground_state(t_kwargs=t_kwargs, l_kwargs=l_kwargs)
-    e_rccsd = rccsd.compute_energy() + e_ref
+    e_rccsd = rccsd.compute_energy()
 
     """
     Potentially compute more propeties such as dipole moment


### PR DESCRIPTION
Compute reference energy with system.compute_reference_energy and update the groundstate test for RCCSD.