### PR TITLE
Fix index order in diagonal blocks of rcc2 and rccsd ob density matrices

### DIFF
--- a/coupled_cluster/rcc2/density_matrices.py
+++ b/coupled_cluster/rcc2/density_matrices.py
@@ -9,8 +9,8 @@ def compute_one_body_density_matrix(t1, t2, l1, l2, o, v, np, out=None):
     rho = np.zeros((nocc + nvirt, nocc + nvirt), dtype=t1.dtype)
 
     rho[: o.stop, : o.stop] += 2 * np.eye(o.stop)
-    rho[o, o] -= contract("kjab,baik->ij", l2, t2)
-    rho[o, o] -= contract("ja,ai->ij", l1, t1)
+    rho[o, o] -= contract("kjab,baik->ji", l2, t2)
+    rho[o, o] -= contract("ja,ai->ji", l1, t1)
 
     rho[v, o] = 2 * t1
     rho[v, o] -= contract("ak,jkcb,bcij->ai", t1, l2, t2, optimize=True)
@@ -21,7 +21,7 @@ def compute_one_body_density_matrix(t1, t2, l1, l2, o, v, np, out=None):
 
     rho[o, v] = l1
 
-    rho[v, v] = contract("ia,bi->ab", l1, t1)
-    rho[v, v] += contract("ijac,bcij->ab", l2, t2)
+    rho[v, v] = contract("ia,bi->ba", l1, t1)
+    rho[v, v] += contract("ijac,bcij->ba", l2, t2)
 
     return rho

--- a/coupled_cluster/rccsd/density_matrices.py
+++ b/coupled_cluster/rccsd/density_matrices.py
@@ -9,20 +9,21 @@ def compute_one_body_density_matrix(t1, t2, l1, l2, o, v, np, out=None):
     rho = np.zeros((nocc + nvirt, nocc + nvirt), dtype=t1.dtype)
 
     rho[o, o] += 2 * np.eye(nocc)
-    rho[o, o] -= contract("kjab,baik->ij", l2, t2)
-    rho[o, o] -= contract("ja,ai->ij", l1, t1)
+    rho[o, o] -= contract("kjab,baik->ji", l2, t2)
+    rho[o, o] -= contract("ja,ai->ji", l1, t1)
 
     rho[v, o] = 2 * t1
+    rho[v, o] += 2 * contract("jb,abij->ai", l1, t2)
+    rho[v, o] -= contract("jb,abji->ai", l1, t2)
+
+    rho[v, o] -= contract("jb,aj,bi->ai", l1, t1, t1, optimize=True)
     rho[v, o] -= contract("ak,jkcb,bcij->ai", t1, l2, t2, optimize=True)
     rho[v, o] -= contract("ci,jkcb,abjk->ai", t1, l2, t2, optimize=True)
-    rho[v, o] -= contract("jb,abji->ai", l1, t2)
-    rho[v, o] += 2 * contract("jb,abij->ai", l1, t2)
-    rho[v, o] -= contract("jb,aj,bi->ai", l1, t1, t1, optimize=True)
 
     rho[o, v] = l1
 
-    rho[v, v] = contract("ia,bi->ab", l1, t1)
-    rho[v, v] += contract("ijac,bcij->ab", l2, t2)
+    rho[v, v] = contract("ia,bi->ba", l1, t1)
+    rho[v, v] += contract("ijac,bcij->ba", l2, t2)
 
     return rho
 


### PR DESCRIPTION
The index order used for the diagonal blocks is inconsistent with the definition of the obd density matrix we have used, that is, 
rho^q_p = <tilde(psi)|a_p^\dagger a_q|psi>. This leads to errors in the static dipole moment when using complex orbitals from Quest. Correcting the index order solves this problem. This index order is consistent with the index order used in the rnoccd code. 