### PR TITLE
CCD rho_abij factorized

### DIFF
--- a/coupled_cluster/rccd/density_matrices.py
+++ b/coupled_cluster/rccd/density_matrices.py
@@ -91,6 +91,7 @@ def add_rho_abij(t, l, o, v, out, np):
 
     out[v, v, o, o] += 2 * tt
 
+
 def add_rho_jbia(t, l, o, v, out, np):
 
     no = o.stop


### PR DESCRIPTION
This pull request replaces the old gristmill-generated expression for the matrix element rho^{ab}_{ij} of the rccd/roaccd two-body density matrix. The roaccd and roatdccd tests, which depend on rho^{ab}_{ij}, are still passing. 