### PR TITLE
Add Hellman-Feynman test for ccd, rccd, ccsd, rccsd, oaccd and roaccd.

### DIFF
--- a/tests/test_hellman_feynman.py
+++ b/tests/test_hellman_feynman.py
@@ -8,7 +8,7 @@ from coupled_cluster.mix import DIIS
 from coupled_cluster import CCD, OACCD, RCCD, ROACCD, CCSD, RCCSD
 
 """
-These tests tests if the Hellman-Feynman theorem
+These tests test if the Hellman-Feynman theorem
 	\frac{d}{de}<\tilde{\Psi}|\hat{H}+e*\hat{V}|\Psi> = <\tilde{\Psi}|\hat{V}|\Psi>,
 holds with \hat{V} = \hat{r}. 
 


### PR DESCRIPTION
This pull request adds the "Hellman-Feynman test" for CCD, rccd, ccsd, rccsd, oaccd, and roaccd. 

These tests test if the Hellman-Feynman theorem
	$$\frac{d}{de}<\tilde{\Psi}|\hat{H}+e \hat{V}|\Psi> = <\tilde{\Psi}|\hat{V}|\Psi>,$$
holds with $\hat{V} = \hat{r}$. 

The derivative is computed with the central finite difference approximation
	$$\frac{d}{de}<\tilde{\Psi}|\hat{H}+e \hat{V}|\Psi> \approx \frac{E(e+\Delta e) - E(e - \Delta e)}{2 \Delta e} + O(\Delta e^2),$$ 
where 
	$$E(e) = <\tilde{\Psi}|\hat{H}+e \hat{V}|\Psi>.$$

Thus, for $\hat{V} = \hat{r}$ we expect that
	$$<\tilde{\Psi}|\hat{r}|\Psi> \approx \frac{E(e+\Delta e) - E(e - \Delta e)}{2 \Delta e}+ O(\Delta e^2).$$